### PR TITLE
Render flex overflow

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,53 @@
+PODS:
+  - Flutter (1.0.0)
+  - flutter_sound_core (8.5.0)
+  - flutter_sound_lite (8.5.0):
+    - Flutter
+    - flutter_sound_core (= 8.5.0)
+  - path_provider_ios (0.0.1):
+    - Flutter
+  - permission_handler_apple (9.0.4):
+    - Flutter
+  - shared_preferences_ios (0.0.1):
+    - Flutter
+  - sound_stream (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - flutter_sound_lite (from `.symlinks/plugins/flutter_sound_lite/ios`)
+  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
+  - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - sound_stream (from `.symlinks/plugins/sound_stream/ios`)
+
+SPEC REPOS:
+  trunk:
+    - flutter_sound_core
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  flutter_sound_lite:
+    :path: ".symlinks/plugins/flutter_sound_lite/ios"
+  path_provider_ios:
+    :path: ".symlinks/plugins/path_provider_ios/ios"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
+  shared_preferences_ios:
+    :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  sound_stream:
+    :path: ".symlinks/plugins/sound_stream/ios"
+
+SPEC CHECKSUMS:
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  flutter_sound_core: d9396f10752a0df9aa3197f4c431d62d934918cc
+  flutter_sound_lite: 175808b357d0b3eeee1345843545bb2fbde06e6c
+  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
+  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  sound_stream: eba0f2a5994b91d9e5009a739df6e98515a7b44f
+
+PODFILE CHECKSUM: df56bac7375b256a1e70341526550836cb2adaf9
+
+COCOAPODS: 1.11.3

--- a/lib/app/View/app_createaccountpage.dart
+++ b/lib/app/View/app_createaccountpage.dart
@@ -48,90 +48,119 @@ class AppCreateAccountPage extends StatelessWidget {
         height: MediaQuery.of(context).size.height,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            const Text(
-              "Ange dina uppgifter för att skapa ett konto",
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
-            ),
-            TextFormField(
-              controller: context.watch<VM>().email,
-              decoration: const InputDecoration(
-                labelText: 'Epost',
+          children: [//All children are wrapped in Flexible to adjust when the keyboard is used
+            const Flexible(
+              flex: 1,
+              child: Text(
+                "Ange dina uppgifter för att skapa ett konto",
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
               ),
             ),
-            TextFormField(
-              controller: context.watch<VM>().username,
-              decoration: const InputDecoration(
-                labelText: 'Användarnamn',
-              ),
-            ),
-            TextFormField(
-              controller: context.watch<VM>().phone,
-              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-              decoration: const InputDecoration(
-                labelText: 'Telefonnummer',
-              ),
-            ),
-            TextFormField(
-              controller: context.watch<VM>().password1,
-              obscureText: !context.watch<VM>().passwordVisibilityCreate,
-              decoration: const InputDecoration(
-                labelText: 'Lösenord',
-              ),
-              keyboardType: TextInputType.visiblePassword,
-            ),
-            TextFormField(
-              controller: context.watch<VM>().password2,
-              obscureText: !context.watch<VM>().passwordVisibilityCreate,
-              decoration: const InputDecoration(
-                labelText: 'Bekräfta lösenord',
-              ),
-            ),
-            Row(
-              children: [
-                Checkbox(
-                  splashRadius: 0,
-                  focusColor: Colors.transparent,
-                  hoverColor: Colors.transparent,
-                  value: context.watch<VM>().passwordVisibilityCreate,
-                  onChanged: (_) {
-                    context.read<VM>().changePasswordVisibilityCreate();
-                  },
+            Flexible(
+              flex: 2,
+              child: TextFormField(
+                controller: context.watch<VM>().email,
+                textInputAction: TextInputAction.next, // Moves focus to next textfield.
+                decoration: const InputDecoration(
+                  labelText: 'Epost',
                 ),
-                InkWell(
-                  splashColor: Colors.transparent,
-                  highlightColor: Colors.transparent,
-                  hoverColor: Colors.transparent,
-                  onTap: () {
-                    context.read<VM>().changePasswordVisibilityCreate();
-                  },
-                  child: const Text("Visa lösenord"),
-                ),
-              ],
+              ),
             ),
-            SizedBox(
-              width: 200,
-              height: 50,
-              child: GradientElevatedButton(
-                child: const Text(
-                  'Skapa konto',
-                  style: TextStyle(
-                    fontSize: 25,
-                    color: Colors.white,
-                    fontWeight: FontWeight.bold,
+            Flexible(
+              flex: 2,
+              child: TextFormField(
+                controller: context.watch<VM>().username,
+                textInputAction: TextInputAction.next, // Moves focus to next.
+                decoration: const InputDecoration(
+                  labelText: 'Användarnamn',
+                ),
+              ),
+            ),
+            Flexible(
+              flex: 2,
+              child: TextFormField(
+                controller: context.watch<VM>().phone,
+                textInputAction: TextInputAction.next, // Moves focus to next.
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                decoration: const InputDecoration(
+                  labelText: 'Telefonnummer',
+                ),
+              ),
+            ),
+            Flexible(
+              flex: 2,
+              child: TextFormField(
+                controller: context.watch<VM>().password1,
+                textInputAction: TextInputAction.next, // Moves focus to next.
+                obscureText: !context.watch<VM>().passwordVisibilityCreate,
+                decoration: const InputDecoration(
+                  labelText: 'Lösenord',
+                ),
+                keyboardType: TextInputType.visiblePassword,
+              ),
+            ),
+            Flexible(
+              flex: 2,
+              child: TextFormField(
+                controller: context.watch<VM>().password2,
+                textInputAction: TextInputAction.done, // Close keyboard.
+                obscureText: !context.watch<VM>().passwordVisibilityCreate,
+                decoration: const InputDecoration(
+                  labelText: 'Bekräfta lösenord',
+                ),
+              ),
+            ),
+            Flexible(
+              flex: 1,
+              child: Row(
+                  children: [
+                    Checkbox(
+                      splashRadius: 0,
+                      focusColor: Colors.transparent,
+                      hoverColor: Colors.transparent,
+                      value: context.watch<VM>().passwordVisibilityCreate,
+                      onChanged: (_) {
+                        context.read<VM>().changePasswordVisibilityCreate();
+                      },
+                    ),
+                    InkWell(
+                      splashColor: Colors.transparent,
+                      highlightColor: Colors.transparent,
+                      hoverColor: Colors.transparent,
+                      onTap: () {
+                        context.read<VM>().changePasswordVisibilityCreate();
+                      },
+                      child: const Text("Visa lösenord"),
+                    ),
+                  ],
+                ),
+            ),
+            Flexible(
+              flex: 2,
+              child: SizedBox(
+                  width: 200,
+                  height: 50,
+                  child: GradientElevatedButton(
+                    child: const Text(
+                      'Skapa konto',
+                      style: TextStyle(
+                        fontSize: 25,
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    onPressed: () {
+                      context.read<VM>().comparePw(context);
+                    },
+                    gradient: const LinearGradient(
+                        begin: Alignment.centerLeft,
+                        end: Alignment.centerRight,
+                        colors: [
+                          Colors.greenAccent,
+                          Colors.blueAccent,
+                        ]),
                   ),
                 ),
-                onPressed: () {
-                  context.read<VM>().comparePw(context);
-                },
-                gradient: const LinearGradient(
-                    begin: Alignment.centerLeft,
-                    end: Alignment.centerRight,
-                    colors: [
-                      Colors.greenAccent,
-                      Colors.blueAccent,
-                    ]),
-              ),
             ),
           ],
         ),

--- a/lib/app/View/app_loginpage.dart
+++ b/lib/app/View/app_loginpage.dart
@@ -49,149 +49,196 @@ class AppLoginPage extends StatelessWidget {
         height: MediaQuery.of(context).size.height,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                const Text(
-                  'Välkommen',
-                  style: TextStyle(fontSize: 30, fontWeight: FontWeight.bold),
-                ),
-                const Text(
-                  'Vänligen ange dina inloggningsuppgifter',
-                  style: TextStyle(
-                    fontSize: 16,
-                  ),
-                ),
-                const SizedBox(
-                  height: 40,
-                ),
-                TextFormField(
-                  controller: context.watch<VM>().login,
-                  decoration: const InputDecoration(
-                    labelText: 'E-post eller telefonnummer',
-                  ),
-                ),
-                TextFormField(
-                  controller: context.watch<VM>().password,
-                  decoration: InputDecoration(
-                    labelText: 'Lösenord',
-                    suffixIcon: IconButton(
-                      hoverColor: Colors.transparent,
-                      splashRadius: null,
-                      splashColor: Colors.transparent,
-                      icon: Icon(
-                        // Based on passwordVisible state choose the icon
-                        context.read<VM>().passwordVisibilityLogin
-                            ? Icons.visibility
-                            : Icons.visibility_off,
-                        color: Theme.of(context).primaryColorDark,
-                      ),
-                      onPressed: () {
-                        // Update the state i.e. toogle the state of passwordVisible variable
-                        context.read<VM>().changePasswordVisibilityLogin();
-                      },
-                    ),
-                  ),
-                  obscureText: !context.watch<VM>().passwordVisibilityLogin,
-                ),
-                Align(
-                  alignment: Alignment.bottomRight,
-                  child: TextButton(
-                    onPressed: () {
-                      /// Implement password reset
-                    },
-                    child: const Text('Glömt ditt lösenord?'),
-                  ),
-                ),
-                const SizedBox(
-                  height: 30,
-                ),
-                SizedBox(
-                  width: 200,
-                  height: 50,
-                  child: GradientElevatedButton(
-                    child: const Text(
-                      'Logga in',
-                      style: TextStyle(
-                        fontSize: 25,
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
+          children: [//All children are wrapped in flexible to adjust when keyboard is used
+            Flexible(
+                flex: 3,
+                child: Column(
+                  //mainAxisAlignment: MainAxisAlignment.center,
+                  children: [//All children are wrapped in flexible to adjust when keyboard is used
+                    const Flexible(
+                      flex: 2,
+                      child: Text(
+                        'Välkommen',
+                        style: TextStyle(fontSize: 30, fontWeight: FontWeight.bold),
                       ),
                     ),
-                    onPressed: () {
-                      context.read<VM>().loginAttempt(context);
-                    },
-                    gradient: const LinearGradient(
-                        begin: Alignment.centerLeft,
-                        end: Alignment.centerRight,
-                        colors: [
-                          Colors.greenAccent,
-                          Colors.blueAccent,
-                        ]),
-                  ),
-                ),
-              ],
-            ),
-            Column(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Text(
-                      'Välkommen att logga in som ',
-                      style: TextStyle(fontSize: 16),
-                    ),
-                    InkWell(
-                      splashColor: Colors.transparent,
-                      highlightColor: Colors.transparent,
-                      hoverColor: Colors.transparent,
-                      onTap: () {
-                        context.read<VM>().guestSign(context);
-                      },
-                      child: const Text(
-                        "gäst",
-                        style: TextStyle(
-                            fontSize: 16,
-                            color: Colors.blueAccent,
-                            fontWeight: FontWeight.bold),
-                      ),
-                    ),
-                  ],
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(15),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Text(
-                        'Inget konto än? ',
+                    const Flexible(
+                      flex: 1,
+                      child: Text(
+                        'Vänligen ange dina inloggningsuppgifter',
                         style: TextStyle(
                           fontSize: 16,
                         ),
                       ),
-                      InkWell(
-                        splashColor: Colors.transparent,
-                        highlightColor: Colors.transparent,
-                        hoverColor: Colors.transparent,
-                        onTap: () {
-                          context
-                              .read<VM>()
-                              .changePage(context, constant.createAcc);
-                        },
-                        child: const Text(
-                          "Registrera dig här",
-                          style: TextStyle(
-                              fontSize: 16,
-                              color: Colors.blueAccent,
-                              fontWeight: FontWeight.bold),
+                    ),
+
+                    const Flexible(
+                      flex: 1,
+                      child: SizedBox(
+                        height: 40,
+                      ),
+                    ),
+                    Flexible(
+                      flex: 3,
+                      child: TextFormField(
+                        controller: context
+                            .watch<VM>()
+                            .login,
+                        textInputAction: TextInputAction.next, // Moves focus to next text field.
+                        decoration: const InputDecoration(
+                          labelText: 'E-post eller telefonnummer',
                         ),
                       ),
-                    ],
-                  ),
+                    ),
+                    Flexible(
+                      flex: 3,
+                      child: TextFormField(
+                        controller: context
+                            .watch<VM>()
+                            .password,
+                        textInputAction: TextInputAction.done, // Close keyboard.
+                        decoration: InputDecoration(
+                          labelText: 'Lösenord',
+                          suffixIcon: IconButton(
+                            hoverColor: Colors.transparent,
+                            splashRadius: null,
+                            splashColor: Colors.transparent,
+                            icon: Icon(
+                              // Based on passwordVisible state choose the icon
+                              context
+                                  .read<VM>()
+                                  .passwordVisibilityLogin
+                                  ? Icons.visibility
+                                  : Icons.visibility_off,
+                              color: Theme
+                                  .of(context)
+                                  .primaryColorDark,
+                            ),
+                            onPressed: () {
+                              // Update the state i.e. toogle the state of passwordVisible variable
+                              context.read<VM>().changePasswordVisibilityLogin();
+                            },
+                          ),
+                        ),
+                        obscureText: !context.watch<VM>().passwordVisibilityLogin,
+                      ),
+                    ),
+                    Flexible(
+                      flex: 2,
+                      child: Align(
+                        alignment: Alignment.bottomRight,
+                        child: TextButton(
+                          onPressed: () {
+                            /// Implement password reset
+                          },
+                          child: const Text('Glömt ditt lösenord?'),
+                        ),
+                      ),
+                    ),
+                    const Flexible(
+                      flex: 1,
+                      child: SizedBox(
+                        height: 30,
+                      ),
+                    ),
+                    Flexible(
+                      flex: 3,
+                      child: SizedBox(
+                        width: 200,
+                        height: 50,
+                        child: GradientElevatedButton(
+                          child: const Text(
+                            'Logga in',
+                            style: TextStyle(
+                              fontSize: 25,
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          onPressed: () {
+                            context.read<VM>().loginAttempt(context);
+                          },
+                          gradient: const LinearGradient(
+                              begin: Alignment.centerLeft,
+                              end: Alignment.centerRight,
+                              colors: [
+                                Colors.greenAccent,
+                                Colors.blueAccent,
+                              ]),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+            ),
+            Flexible(
+                flex: 1,
+                child: Column(
+                  //mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    Flexible(
+                      flex: 1,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Text(
+                            'Välkommen att logga in som ',
+                            style: TextStyle(fontSize: 16),
+                          ),
+                          InkWell(
+                            splashColor: Colors.transparent,
+                            highlightColor: Colors.transparent,
+                            hoverColor: Colors.transparent,
+                            onTap: () {
+                              context.read<VM>().guestSign(context);
+                            },
+                            child: const Text(
+                              "gäst",
+                              style: TextStyle(
+                                  fontSize: 16,
+                                  color: Colors.blueAccent,
+                                  fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Flexible(
+                      flex: 1,
+                      child: Padding(
+                        padding: const EdgeInsets.all(10),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Text(
+                              'Inget konto än? ',
+                              style: TextStyle(
+                                fontSize: 16,
+                              ),
+                            ),
+                            InkWell(
+                              splashColor: Colors.transparent,
+                              highlightColor: Colors.transparent,
+                              hoverColor: Colors.transparent,
+                              onTap: () {
+                                context
+                                    .read<VM>()
+                                    .changePage(context, constant.createAcc);
+                              },
+                              child: const Text(
+                                "Registrera dig här",
+                                style: TextStyle(
+                                    fontSize: 16,
+                                    color: Colors.blueAccent,
+                                    fontWeight: FontWeight.bold),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
             ),
           ],
         ),


### PR DESCRIPTION
Wrapped widgets in Flexible to be able to adjust when keyboard is used in login page and create account page. This removes the error message of "bottom overflow by x pixels".
Also added textInputAction to the textfields so that you can automatically move to the next textfield when finished with one. The layout slightly changed when flexible was added but it can be adjusted using flex and fit to achieve the desired layout. A Podfile.lock was also pushed.