### PR TITLE
Send stream events such as channel updates among sound data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 /build/
 
 # Web related
-lib/--Bin (Deprecated)/generated_plugin_registrant.dart
+lib/generated_plugin_registrant.dart
 
 # Symbolication related
 app.*.symbols

--- a/lib/apis/stream_client.dart
+++ b/lib/apis/stream_client.dart
@@ -5,9 +5,12 @@ import 'package:cmt_projekt/apis/prefs.dart';
 import 'package:cmt_projekt/models/streammessage_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sound_lite/flutter_sound.dart';
+import 'package:provider/provider.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../models/query_model.dart';
+import '../view_models/main_vm.dart';
+import '../view_models/stream_vm.dart';
 import '../widgets/dialog_timer.dart';
 import '../constants.dart';
 import '../environment.dart';
@@ -51,7 +54,12 @@ class StreamClient {
       } else {
         playSound(event);
       }
-    }, onDone: () {channelClosedDialog(context);});
+    }, onDone: () {
+      // 1005 stands for "closed with no exit status" so show only when server gives exit code
+      if(client.closeCode != 1005) {
+        channelClosedDialog(context);
+      }
+    });
   }
 
   Future<void> stopSound() async {
@@ -119,12 +127,15 @@ class StreamClient {
                 const DialogTimer(time: 10,), //change textstyle in widget
                 ElevatedButton(
                   onPressed: () {
-                    if (Navigator.canPop(context)) {
-                      Navigator.popUntil(context, (route) {
-                        return route.settings.name == home;
-                      });
-                    }
+                    context.read<StreamViewModel>().closeClient();
+                    context.read<MainViewModel>().willPopCallback();
+                    Navigator.pop(context);
+                    Navigator.pop(context);
                   },
+                  style: ButtonStyle(
+                    backgroundColor: MaterialStateProperty.all(Colors.black45),
+                    foregroundColor: MaterialStateProperty.all(Colors.white)
+                  ),
                   child: const Text('Tillbaka till startsidan',
                     style: TextStyle(
                       fontSize: 24,
@@ -136,10 +147,14 @@ class StreamClient {
                   onPressed: () {
                     Navigator.pop(context);
                   },
+                  style: ButtonStyle(
+                    backgroundColor: MaterialStateProperty.all(Colors.black45),
+                    foregroundColor: MaterialStateProperty.all(Colors.white)
+                  ),
                   child: const Text('Byt kanal',
                     style: TextStyle(
                       fontSize: 24,
-                      fontWeight: FontWeight.bold,
+                      fontWeight: FontWeight.bold
                     ),
                   ),
                 ),

--- a/lib/apis/stream_client.dart
+++ b/lib/apis/stream_client.dart
@@ -12,7 +12,7 @@ import '../widgets/dialog_timer.dart';
 import '../constants.dart';
 import '../environment.dart';
 
-class Client {
+class StreamClient {
   late WebSocketChannel client;
   late FlutterSoundPlayer? _player;
   StreamController<Food>? foodStreamController =
@@ -20,7 +20,7 @@ class Client {
   StreamController<QueryModel> msgController =
       StreamController<QueryModel>.broadcast();
 
-  Client(FlutterSoundPlayer? player) {
+  StreamClient(FlutterSoundPlayer? player) {
     _player = player;
     client = WebSocketChannel.connect(Uri.parse(serverConnection));
 
@@ -70,7 +70,7 @@ class Client {
 
   sendUpdate(StreamMessage msg){
     msg.intent = "u";
-    client.sink.add(msg);
+    client.sink.add(jsonEncode(msg));
   }
 
   void channelClosedDialog(context) {

--- a/lib/apis/stream_client.dart
+++ b/lib/apis/stream_client.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:cmt_projekt/apis/prefs.dart';
 import 'package:cmt_projekt/models/streammessage_model.dart';
-import 'package:cmt_projekt/widgets/ChannelClosedDialog.dart';
+import 'package:cmt_projekt/widgets/channel_closed_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sound_lite/flutter_sound.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -94,7 +94,7 @@ class StreamClient {
     showDialog(
       context: context,
       barrierDismissible: false, // user must tap a button!
-      builder: ChannelClosedDialog().build,
+      builder: const ChannelClosedDialog().build,
     );
   }
 }

--- a/lib/apis/stream_client.dart
+++ b/lib/apis/stream_client.dart
@@ -3,37 +3,39 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:cmt_projekt/apis/prefs.dart';
 import 'package:cmt_projekt/models/streammessage_model.dart';
+import 'package:cmt_projekt/widgets/ChannelClosedDialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sound_lite/flutter_sound.dart';
-import 'package:provider/provider.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../models/query_model.dart';
-import '../view_models/main_vm.dart';
-import '../view_models/stream_vm.dart';
-import '../widgets/dialog_timer.dart';
-import '../constants.dart';
 import '../environment.dart';
 
+/// A Class for handling a websocket stream to the server
 class StreamClient {
+  /// The websocket connection to the stream server
   late WebSocketChannel client;
+  /// The player object that plays sound
   late FlutterSoundPlayer? _player;
+  /// A stream controller used by recorders to forward data to the websocket connection
   StreamController<Food>? foodStreamController =
       StreamController<Food>.broadcast();
+  /// A stream controller for forwarding updated channel data to various pages.
   StreamController<QueryModel> msgController =
       StreamController<QueryModel>.broadcast();
 
+  /// Initiates the Flutter sound player and setups a connection to the server
   StreamClient(FlutterSoundPlayer? player) {
     _player = player;
     client = WebSocketChannel.connect(Uri.parse(serverConnection));
 
-    if (Prefs().getIntent() == "j") {
+    if (Prefs().getIntent() == "j") { // sends a json msg to server on which host to join/listen
       debugPrint(Prefs().getIntent().toString());
       client.sink.add(jsonEncode(StreamMessage.join(
           uid: Prefs().storedData.get("uid").toString(),
           channelType: "a",
           hostId: Prefs().storedData.get("joinChannelID").toString())));
-    } else {
+    } else { // sends a json msg to server with intent to host
       client.sink.add(jsonEncode(StreamMessage.host(
         uid: Prefs().storedData.get("uid").toString(),
         channelType: "a",
@@ -42,14 +44,17 @@ class StreamClient {
       )));
     }
 
-    foodStreamController!.stream.listen((event) { sendData(event); });
+    // when the stream gets recording data then send it to the stream server
+    foodStreamController!.stream.listen((event) { sendData(event as FoodData); });
   }
 
+  /// A handler for receiving data from the server.
+  /// It differentiates between string and binary data so strings are json decoded and sent to [msgController].
+  /// While binary (sound) data is handled by the [playSound] method.
   void listen(context) {
     client.stream.listen((event) {
       if(event.runtimeType == String){
         final msg = QueryModel.fromJson(jsonDecode(event));
-        logger.d(msg);
         msgController.sink.add(msg);
       } else {
         playSound(event);
@@ -62,107 +67,34 @@ class StreamClient {
     });
   }
 
+  ///Stops audio playback, see [FlutterSoundPlayer.stopPlayer].
   Future<void> stopSound() async {
     await _player!.stopPlayer();
   }
 
-  Future<void> playSound(event) async {
+  /// Plays audio data provided and adds to the players foodsink. See [FlutterSoundPlayer.foodSink].
+  Future<void> playSound(TypedData event) async {
     Uint8List list = Uint8List.sublistView(event);
     _player!.foodSink!.add(FoodData(list));
   }
 
-  void sendData(data) {
-    FoodData fd = data;
-    client.sink.add(fd.data);
+  /// Sends binary audio data to the server
+  void sendData(FoodData data) {
+    client.sink.add(data.data);
   }
 
+  /// Sends a json message to the server with intent to update channel info.
   sendUpdate(StreamMessage msg){
     msg.intent = "u";
     client.sink.add(jsonEncode(msg));
   }
 
+  /// Shows a [ChannelClosedDialog]
   void channelClosedDialog(context) {
     showDialog(
       context: context,
       barrierDismissible: false, // user must tap a button!
-      builder: (context) {
-        return Dialog(
-          shape: const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(20.0))
-          ),
-          child: Container(
-            height: MediaQuery.of(context).size.height*0.4,
-            width: MediaQuery.of(context).size.width*0.9,
-            decoration: BoxDecoration(
-                border: Border.all(
-                  color: Colors.black,
-                  width: 2,
-                ),
-                borderRadius: const BorderRadius.all(Radius.circular(20.0)),
-                gradient: const LinearGradient(
-                    begin: Alignment.centerLeft,
-                    end: Alignment.centerRight,
-                    colors: [
-                      Colors.greenAccent,
-                      Colors.blueAccent,
-                    ])
-            ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                const Text('Sändningen är avslutad',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                  ),
-                ),
-                const Text('Byter till ny kanal om:',
-                  style: TextStyle(
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                  ),
-                ),
-                const DialogTimer(time: 10,), //change textstyle in widget
-                ElevatedButton(
-                  onPressed: () {
-                    context.read<StreamViewModel>().closeClient();
-                    context.read<MainViewModel>().willPopCallback();
-                    Navigator.pop(context);
-                    Navigator.pop(context);
-                  },
-                  style: ButtonStyle(
-                    backgroundColor: MaterialStateProperty.all(Colors.black45),
-                    foregroundColor: MaterialStateProperty.all(Colors.white)
-                  ),
-                  child: const Text('Tillbaka till startsidan',
-                    style: TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-                ElevatedButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                  style: ButtonStyle(
-                    backgroundColor: MaterialStateProperty.all(Colors.black45),
-                    foregroundColor: MaterialStateProperty.all(Colors.white)
-                  ),
-                  child: const Text('Byt kanal',
-                    style: TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.bold
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
+      builder: ChannelClosedDialog().build,
     );
   }
 }

--- a/lib/models/stream_model.dart
+++ b/lib/models/stream_model.dart
@@ -8,5 +8,5 @@ class StreamModel {
 
   bool isInitiated = false;
 
-  Client? c;
+  StreamClient? streamClient;
 }

--- a/lib/models/streammessage_model.dart
+++ b/lib/models/streammessage_model.dart
@@ -33,6 +33,7 @@ class StreamMessage {
     required this.channelType,
     required this.uid
 }){
+    hostId = uid;
     intent = "u";
 }
 

--- a/lib/models/streammessage_model.dart
+++ b/lib/models/streammessage_model.dart
@@ -2,7 +2,7 @@
 ///The purpose of this class is to relay information between the server and client.
 class StreamMessage {
   String uid;
-  String? hostOrJoin;
+  String? intent;
   String? hostId;
   String channelType;
   String? channelName;
@@ -16,7 +16,7 @@ class StreamMessage {
     required this.category,
   }) {
     hostId = uid;
-    hostOrJoin = "h";
+    intent = "h";
   }
 
   ///An instance of StreamMessage for a join request.
@@ -24,13 +24,22 @@ class StreamMessage {
     required this.uid,
     required this.hostId,
     required this.channelType}) {
-    hostOrJoin = "j";
+    intent = "j";
   }
+
+  StreamMessage.update({
+    required this.channelName,
+    required this.category,
+    required this.channelType,
+    required this.uid
+}){
+    intent = "u";
+}
 
   ///Konverterar meddelandet till json
   Map<String, dynamic> toJson() => {
         'uid': uid,
-        'hostOrJoin': hostOrJoin,
+        'hostOrJoin': intent,
         'hostId': hostId,
         'channelType': channelType,
         'channelName': channelName,
@@ -40,7 +49,7 @@ class StreamMessage {
   ///Creates an instance of StreamMessage from jason.
   StreamMessage.fromJson(Map<String, dynamic> json)
       : uid = json['uid'],
-        hostOrJoin = json['hostOrJoin'],
+        intent = json['hostOrJoin'],
         hostId = json['hostId'],
         channelType = json['channelType'],
         channelName = json['channelName'],

--- a/lib/view_models/main_vm.dart
+++ b/lib/view_models/main_vm.dart
@@ -99,7 +99,7 @@ class MainViewModel with ChangeNotifier {
 
   ///Returns the users uID.
   String? getUid() {
-    return Prefs().storedData.get("uid").toString();
+    return Prefs().storedData.getString("uid");
   }
 
   ///Creates a showdialog with webprofilewidget.

--- a/lib/view_models/stream_vm.dart
+++ b/lib/view_models/stream_vm.dart
@@ -1,7 +1,10 @@
 import 'package:cmt_projekt/models/stream_model.dart';
 import 'package:cmt_projekt/apis/stream_client.dart';
+import 'package:cmt_projekt/models/streammessage_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_sound_lite/flutter_sound.dart';
+
+import '../apis/prefs.dart';
 
 typedef Fn = void Function();
 
@@ -11,21 +14,21 @@ class StreamViewModel with ChangeNotifier {
   void startup(context) {
     smodel.player = FlutterSoundPlayer();
     smodel.recorder = FlutterSoundRecorder();
-    smodel.c = Client(smodel.player);
+    smodel.streamClient = StreamClient(smodel.player);
     init().then((value) {
       smodel.isInitiated = true;
-      smodel.c!.listen(context);
+      smodel.streamClient!.listen(context);
     });
   }
 
   Future<bool> closeClient() async {
-    if (smodel.c != null) {
+    if (smodel.streamClient != null) {
       smodel.player!.stopPlayer();
       smodel.recorder!.stopRecorder();
-      smodel.c!.stopSound();
+      smodel.streamClient!.stopSound();
       smodel.isInitiated = false;
-      smodel.c!.client.sink.close();
-      smodel.c = null;
+      smodel.streamClient!.client.sink.close();
+      smodel.streamClient = null;
     }
 
     return true;
@@ -83,7 +86,7 @@ class StreamViewModel with ChangeNotifier {
     await smodel.recorder!.startRecorder(
       codec: Codec.pcm16,
       toStream: smodel
-          .c!.foodStreamController!.sink, // ***** THIS IS THE LOOP !!! *****
+          .streamClient!.foodStreamController!.sink, // ***** THIS IS THE LOOP !!! *****
       sampleRate: 44000,
       numChannels: 1,
     );
@@ -109,5 +112,15 @@ class StreamViewModel with ChangeNotifier {
     } else {
       record();
     }
+  }
+
+  sendUpdate(BuildContext context){
+    final StreamClient c = smodel.streamClient!;
+    c.sendUpdate(StreamMessage.update(
+        channelName:  Prefs().storedData.getString("channelName"),
+        category: Prefs().storedData.getString("category"),
+        channelType: "a",
+        uid: Prefs().storedData.getString("uid")!
+    ));
   }
 }

--- a/lib/views/golivesettings_view.dart
+++ b/lib/views/golivesettings_view.dart
@@ -6,7 +6,7 @@ import 'package:gradient_ui_widgets/gradient_ui_widgets.dart';
 import 'package:provider/provider.dart';
 
 class GoLiveSettings extends StatelessWidget {
-  const GoLiveSettings({Key? key}) : super(key: key);
+  const GoLiveSettings({Key? key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -71,9 +71,14 @@ class GoLiveSettings extends StatelessWidget {
                   child: GradientElevatedButton.icon(
                     onPressed: () {
                       context.read<MainViewModel>().setChannelSettings();
-                      context.read<StreamViewModel>().startup(context);
                       Navigator.pop(context);
-                      Navigator.of(context).popAndPushNamed(hostChannel);
+                      if(context.read<StreamViewModel>().smodel.isInitiated){
+                        logger.i("uwu");
+                        context.read<StreamViewModel>().sendUpdate(context);
+                      } else {
+                        context.read<StreamViewModel>().startup(context);
+                        Navigator.of(context).popAndPushNamed(hostChannel);
+                      }
                     },
                     gradient: const LinearGradient(
                         begin: Alignment.centerLeft,

--- a/lib/views/golivesettings_view.dart
+++ b/lib/views/golivesettings_view.dart
@@ -73,7 +73,6 @@ class GoLiveSettings extends StatelessWidget {
                       context.read<MainViewModel>().setChannelSettings();
                       Navigator.pop(context);
                       if(context.read<StreamViewModel>().smodel.isInitiated){
-                        logger.i("uwu");
                         context.read<StreamViewModel>().sendUpdate(context);
                       } else {
                         context.read<StreamViewModel>().startup(context);

--- a/lib/views/hostchannel_view.dart
+++ b/lib/views/hostchannel_view.dart
@@ -1,5 +1,4 @@
 import 'package:cmt_projekt/apis/navigation_handler.dart';
-import 'package:cmt_projekt/apis/prefs.dart';
 import 'package:cmt_projekt/models/query_model.dart';
 import 'package:cmt_projekt/view_models/stream_vm.dart';
 import 'package:cmt_projekt/view_models/main_vm.dart';
@@ -55,147 +54,134 @@ class _AppHostPageState extends State<AppHostPage> {
             ),
           ),
         ),
-        body: Container(
-          color: Colors.black,
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(
-                      child: SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: Text(
-                          context.watch<MainViewModel>().channelName.value.text,
-                          style: const TextStyle(
-                            color: Colors.greenAccent,
-                            fontSize: 24,
-                            fontWeight: FontWeight.bold,
+        body: StreamBuilder(
+            stream:
+                context.watch<StreamViewModel>().smodel.c!.msgController.stream,
+            initialData: QueryModel.fromJson(
+                {"total": 0, "channelname": "", "username": ""}),
+            builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              } else if (snapshot.connectionState == ConnectionState.active ||
+                  snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.hasError) {
+                  return const Text("error");
+                } else if (snapshot.hasData) {
+                  QueryModel channel = snapshot.data;
+                  return Container(
+                    color: Colors.black,
+                    child: Column(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Expanded(
+                                child: SingleChildScrollView(
+                                  scrollDirection: Axis.horizontal,
+                                  child: Text(
+                                    channel.channelname as String,
+                                    style: const TextStyle(
+                                      color: Colors.greenAccent,
+                                      fontSize: 24,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.only(left: 8.0),
+                                child: Text(
+                                  channel.username as String,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 20,
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 8.0),
-                      child: Text(
-                        context.watch<MainViewModel>().getEmail().toString(),
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 20,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-                child: Row(
-                  children: [
-                    const Icon(
-                      Icons.person,
-                      color: Colors.white,
-                    ),
-                    StreamBuilder(
-                        stream: context
-                            .watch<MainViewModel>()
-                            .databaseAPI
-                            .channelController
-                            .stream,
-                        initialData: 0,
-                        builder: (BuildContext context,
-                            AsyncSnapshot<dynamic> snapshot) {
-                          if (snapshot.connectionState ==
-                              ConnectionState.waiting) {
-                            return const Center(
-                                child: CircularProgressIndicator());
-                          } else if (snapshot.connectionState ==
-                                  ConnectionState.active ||
-                              snapshot.connectionState ==
-                                  ConnectionState.done) {
-                            if (snapshot.hasError) {
-                              return const Text("error");
-                            } else if (snapshot.hasData) {
-                              QueryModel? channel = context
-                                  .read<MainViewModel>()
-                                  .getChannel(
-                                      snapshot.data,
-                                      Prefs()
-                                          .storedData
-                                          .getString("channelName")!);
-                              return Padding(
+                        Padding(
+                          padding: const EdgeInsets.only(left: 8.0, right: 8.0),
+                          child: Row(
+                            children: [
+                              const Icon(
+                                Icons.person,
+                                color: Colors.white,
+                              ),
+                              Padding(
                                 padding: const EdgeInsets.all(8.0),
                                 child: Text(
-                                  channel != null
-                                      ? channel.total.toString()
-                                      : "0",
+                                  channel.total.toString(),
                                   //Här ska countern läggas in för aktiva lyssnare.
                                   style: const TextStyle(
                                     color: Colors.white,
                                     fontSize: 18,
                                   ),
                                 ),
-                              );
-                            } else {
-                              return const Text("No active channels");
-                            }
-                          } else {
-                            return Text("State: ${snapshot.connectionState}");
-                          }
-                        }),
-                    const Text(
-                      'lyssnare',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 18,
-                      ),
+                              ),
+                              const Text(
+                                'lyssnare',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 18,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Container(
+                          margin: const EdgeInsets.all(3),
+                          padding: const EdgeInsets.all(3),
+                          height: MediaQuery.of(context).size.height * 0.4,
+                          width: double.infinity,
+                          alignment: Alignment.center,
+                          decoration: BoxDecoration(
+                            color: Colors.black,
+                            border: Border.all(
+                              color: Colors.white30,
+                              width: 3,
+                            ),
+                          ),
+                          child: Column(
+                            children: [
+                              Icon(
+                                Icons.play_arrow_outlined,
+                                color: Colors.white,
+                                size: MediaQuery.of(context).size.height * 0.15,
+                              ),
+                              Divider(
+                                thickness: 1,
+                                color: Colors.white,
+                                indent:
+                                    MediaQuery.of(context).size.width * 0.05,
+                                endIndent:
+                                    MediaQuery.of(context).size.width * 0.05,
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Column(
+                                  children: [
+                                    liveNotification(context),
+                                    descriptionBox(context),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-              ),
-              Container(
-                margin: const EdgeInsets.all(3),
-                padding: const EdgeInsets.all(3),
-                height: MediaQuery.of(context).size.height * 0.4,
-                width: double.infinity,
-                alignment: Alignment.center,
-                decoration: BoxDecoration(
-                  color: Colors.black,
-                  border: Border.all(
-                    color: Colors.white30,
-                    width: 3,
-                  ),
-                ),
-                child: Column(
-                  children: [
-                    Icon(
-                      Icons.play_arrow_outlined,
-                      color: Colors.white,
-                      size: MediaQuery.of(context).size.height * 0.15,
-                    ),
-                    Divider(
-                      thickness: 1,
-                      color: Colors.white,
-                      indent: MediaQuery.of(context).size.width * 0.05,
-                      endIndent: MediaQuery.of(context).size.width * 0.05,
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Column(
-                        children: [
-                          liveNotification(context),
-                          descriptionBox(context),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
+                  );
+                } else {
+                  return const Text("No active channels");
+                }
+              } else {
+                return Text("State: ${snapshot.connectionState}");
+              }
+            }),
         floatingActionButton: Padding(
           padding:
               EdgeInsets.only(bottom: MediaQuery.of(context).size.height / 20),
@@ -252,14 +238,13 @@ class _AppHostPageState extends State<AppHostPage> {
     } else {
 
      */
-      return SizedBox(
-        width: double.infinity,
-        child: ElevatedButton(
-          onPressed: () {},
-          child: const Text("Lägg till information"),
-        ),
-      );
-
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: () {},
+        child: const Text("Lägg till information"),
+      ),
+    );
   }
 
   Widget liveNotification(BuildContext context) {

--- a/lib/views/hostchannel_view.dart
+++ b/lib/views/hostchannel_view.dart
@@ -56,7 +56,7 @@ class _AppHostPageState extends State<AppHostPage> {
         ),
         body: StreamBuilder(
             stream:
-                context.watch<StreamViewModel>().smodel.c!.msgController.stream,
+                context.watch<StreamViewModel>().smodel.streamClient!.msgController.stream,
             initialData: QueryModel.fromJson(
                 {"total": 0, "channelname": "", "username": ""}),
             builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
@@ -241,7 +241,9 @@ class _AppHostPageState extends State<AppHostPage> {
     return SizedBox(
       width: double.infinity,
       child: ElevatedButton(
-        onPressed: () {},
+        onPressed: () {
+          context.read<MainViewModel>().channelSettings(context);
+        },
         child: const Text("Lägg till information"),
       ),
     );

--- a/lib/views/listenchannel_view.dart
+++ b/lib/views/listenchannel_view.dart
@@ -1,10 +1,8 @@
-import 'package:cmt_projekt/apis/prefs.dart';
 import 'package:cmt_projekt/models/query_model.dart';
 import 'package:cmt_projekt/view_models/stream_vm.dart';
 import 'package:cmt_projekt/view_models/main_vm.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-
 
 ///The page responsible for displaying what the viewer sees when listening to a stream.
 class AppListenPage extends StatelessWidget {
@@ -16,90 +14,49 @@ class AppListenPage extends StatelessWidget {
       context.read<StreamViewModel>().closeClient();
       return context.read<MainViewModel>().willPopCallback();
     }
+
     return WillPopScope(
       onWillPop: willPopCallback,
       child: Scaffold(
-        appBar: PreferredSize(
-          preferredSize: const Size.fromHeight(80.0),
-          child: AppBar(
-            flexibleSpace: Container(
-              decoration: const BoxDecoration(
-                  gradient: LinearGradient(
-                      begin: Alignment.centerLeft,
-                      end: Alignment.centerRight,
-                      colors: [
-                    Colors.greenAccent,
-                    Colors.blueAccent,
-                  ])),
-            ),
-            elevation: 0,
-            centerTitle: true,
-            title: Column(
-              children: [
-                Text(
-                  context.read<MainViewModel>().title.toUpperCase(),
-                  style: const TextStyle(
-                      fontSize: 30, fontWeight: FontWeight.bold),
-                ),
-                const Text(
-                  'Din moderna radioapp',
-                  style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
-                )
-              ],
+          appBar: PreferredSize(
+            preferredSize: const Size.fromHeight(80.0),
+            child: AppBar(
+              flexibleSpace: Container(
+                decoration: const BoxDecoration(
+                    gradient: LinearGradient(
+                        begin: Alignment.centerLeft,
+                        end: Alignment.centerRight,
+                        colors: [
+                      Colors.greenAccent,
+                      Colors.blueAccent,
+                    ])),
+              ),
+              elevation: 0,
+              centerTitle: true,
+              title: Column(
+                children: [
+                  Text(
+                    context.read<MainViewModel>().title.toUpperCase(),
+                    style: const TextStyle(
+                        fontSize: 30, fontWeight: FontWeight.bold),
+                  ),
+                  const Text(
+                    'Din moderna radioapp',
+                    style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+                  )
+                ],
+              ),
             ),
           ),
-        ),
-        body: Container(
-          color: Colors.black,
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(
-                      child: SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: Text(
-                          (Prefs().storedData.getString("channelName")!),
-                          style: const TextStyle(
-                            color: Colors.greenAccent,
-                            fontSize: 24,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ),
-                    Text(
-                      (Prefs().storedData.getString("hostUsername")!),
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 20,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-                child: Row(
-                  children: [
-                    buildStream(context),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+          body: buildStream(context)),
     );
   }
 
   Widget buildStream(BuildContext context) {
     return StreamBuilder(
-      stream: context.watch<MainViewModel>().databaseAPI.channelController.stream,
-      initialData: 0,
+      stream: context.watch<StreamViewModel>().smodel.c!.msgController.stream,
+      initialData:
+          QueryModel.fromJson({"total": 0, "channelname": "", "usename": ""}),
       builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const Center(child: CircularProgressIndicator());
@@ -108,79 +65,129 @@ class AppListenPage extends StatelessWidget {
           if (snapshot.hasError) {
             return const Text("error");
           } else if (snapshot.hasData) {
-            QueryModel? channel = context.read<MainViewModel>().getChannel(
-                snapshot.data, Prefs().storedData.getString("channelName")!);
-            return Flexible(
-                fit: FlexFit.loose,
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
-                        children: [
-                          const Icon(
-                            Icons.person,
-                            color: Colors.white,
-                          ),
-                          Text(
-                            channel != null ? channel.total.toString() : "0",
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 18,
-                            ),
-                          ),
-                          const Text(
-                            ' lyssnare',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 18,
-                            ),
-                          ),
-                        ],
-                      ),
-                      Container(
-                        margin:
-                            const EdgeInsets.only(left: 3, right: 3, top: 100),
-                        height: MediaQuery.of(context).size.height * 0.4,
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                          color: Colors.black,
-                          border: Border.all(
-                            color: Colors.white30,
-                            width: 3,
-                          ),
-                        ),
-                        child: Column(
-                          children: [
-                            Icon(
-                              Icons.play_arrow_outlined,
-                              color: Colors.white,
-                              size: MediaQuery.of(context).size.height * 0.2,
-                            ),
-                            Divider(
-                              thickness: 1,
-                              color: Colors.white,
-                              indent: MediaQuery.of(context).size.width * 0.05,
-                              endIndent:
-                                  MediaQuery.of(context).size.width * 0.05,
-                            ),
-                            const Padding(
-                              padding: EdgeInsets.all(8.0),
-                              child: Text(
-                                "No information",
-                                style: TextStyle(
-                                  fontSize: 20,
-                                  color: Colors.white,
-                                ),
+            QueryModel channel = snapshot.data;
+            return Container(
+              color: Colors.black,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(
+                          child: SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: Text(
+                              channel.channelname as String,
+                              style: const TextStyle(
+                                color: Colors.greenAccent,
+                                fontSize: 24,
+                                fontWeight: FontWeight.bold,
                               ),
                             ),
-                          ],
+                          ),
                         ),
-                      ),
-                    ],
+                        Text(
+                          channel.username as String,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 20,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ));
+                  Padding(
+                    padding: const EdgeInsets.only(left: 8.0, right: 8.0),
+                    child: Row(
+                      children: [
+                        Flexible(
+                            fit: FlexFit.loose,
+                            child: Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Row(
+                                    children: [
+                                      const Icon(
+                                        Icons.person,
+                                        color: Colors.white,
+                                      ),
+                                      Text(
+                                        channel.total.toString(),
+                                        style: const TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 18,
+                                        ),
+                                      ),
+                                      const Text(
+                                        ' lyssnare',
+                                        style: TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 18,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  Container(
+                                    margin: const EdgeInsets.only(
+                                        left: 3, right: 3, top: 100),
+                                    height: MediaQuery.of(context).size.height *
+                                        0.4,
+                                    alignment: Alignment.center,
+                                    decoration: BoxDecoration(
+                                      color: Colors.black,
+                                      border: Border.all(
+                                        color: Colors.white30,
+                                        width: 3,
+                                      ),
+                                    ),
+                                    child: Column(
+                                      children: [
+                                        Icon(
+                                          Icons.play_arrow_outlined,
+                                          color: Colors.white,
+                                          size: MediaQuery.of(context)
+                                                  .size
+                                                  .height *
+                                              0.2,
+                                        ),
+                                        Divider(
+                                          thickness: 1,
+                                          color: Colors.white,
+                                          indent: MediaQuery.of(context)
+                                                  .size
+                                                  .width *
+                                              0.05,
+                                          endIndent: MediaQuery.of(context)
+                                                  .size
+                                                  .width *
+                                              0.05,
+                                        ),
+                                        const Padding(
+                                          padding: EdgeInsets.all(8.0),
+                                          child: Text(
+                                            "No information",
+                                            style: TextStyle(
+                                              fontSize: 20,
+                                              color: Colors.white,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ))
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
           } else {
             return const Text("No active channels");
           }

--- a/lib/views/listenchannel_view.dart
+++ b/lib/views/listenchannel_view.dart
@@ -54,7 +54,7 @@ class AppListenPage extends StatelessWidget {
 
   Widget buildStream(BuildContext context) {
     return StreamBuilder(
-      stream: context.watch<StreamViewModel>().smodel.c!.msgController.stream,
+      stream: context.watch<StreamViewModel>().smodel.streamClient!.msgController.stream,
       initialData:
           QueryModel.fromJson({"total": 0, "channelname": "", "usename": ""}),
       builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {

--- a/lib/widgets/ChannelClosedDialog.dart
+++ b/lib/widgets/ChannelClosedDialog.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../view_models/main_vm.dart';
+import '../view_models/stream_vm.dart';
+import 'dialog_timer.dart';
+
+/// A dialog that shows up when a stream has ended. It has a timer and 2 buttons for navigation.
+class ChannelClosedDialog extends StatelessWidget{
+  /// Sets the page key
+  const ChannelClosedDialog({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(20.0))
+      ),
+      child: Container(
+        height: MediaQuery.of(context).size.height*0.4,
+        width: MediaQuery.of(context).size.width*0.9,
+        decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.black,
+              width: 2,
+            ),
+            borderRadius: const BorderRadius.all(Radius.circular(20.0)),
+            gradient: const LinearGradient(
+                begin: Alignment.centerLeft,
+                end: Alignment.centerRight,
+                colors: [
+                  Colors.greenAccent,
+                  Colors.blueAccent,
+                ])
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            const Text('Sändningen är avslutad',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            const Text('Byter till ny kanal om:',
+              style: TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            const DialogTimer(time: 10,), //change textstyle in widget
+            ElevatedButton(
+              onPressed: () {
+                context.read<StreamViewModel>().closeClient();
+                context.read<MainViewModel>().willPopCallback();
+                Navigator.pop(context);
+                Navigator.pop(context);
+              },
+              style: ButtonStyle(
+                  backgroundColor: MaterialStateProperty.all(Colors.black45),
+                  foregroundColor: MaterialStateProperty.all(Colors.white)
+              ),
+              child: const Text('Tillbaka till startsidan',
+                style: TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              style: ButtonStyle(
+                  backgroundColor: MaterialStateProperty.all(Colors.black45),
+                  foregroundColor: MaterialStateProperty.all(Colors.white)
+              ),
+              child: const Text('Byt kanal',
+                style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+}

--- a/lib/widgets/channel_closed_dialog.dart
+++ b/lib/widgets/channel_closed_dialog.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/server/controllers/channel.dart
+++ b/server/controllers/channel.dart
@@ -31,19 +31,19 @@ class ChannelController {
   ///
   /// **Request Body** a [QueryModel] that contains channelname, uid and category.
   ///
-  /// **Response Body** a [List<QueryModel>] that contains channels without account info.
+  /// **Response Body** a [QueryModel] that contains the channel without account info.
   ///
   /// **Error Status Codes** when it's executed successfully then 200 ok is returned,
   /// 400 when the request body doesn't contain the expected values &
   /// 404 when uid doesn't match an account.
   static addChannel(HttpRequest req, HttpResponse res) async {
     final QueryModel body;
-    final List<Map<String, dynamic>> data;
+    final Map<String, dynamic> data;
 
     try {
       body = QueryModel.fromJson(await req.bodyAsJsonMap);
       await db.createChannel(body.channelname!, body.uid!, body.category!);
-      data = await db.getOnlineChannels();
+      data = await db.getChannel(body.uid!);
     }
     on PostgreSQLException catch (e){ // when uid does not match an account
       logger.e(e.message, [e, e.stackTrace]);
@@ -64,19 +64,19 @@ class ChannelController {
   ///
   /// **Request Body** a [QueryModel] that contains the channelid in the uid field.
   ///
-  /// **Response Body** a [List<QueryModel>] that contains channels without account info.
+  /// **Response Body** a [QueryModel] that contains the channel without account info.
   ///
   /// **Error Status Codes** when it's executed successfully then 200 ok is returned,
   /// 400 when the request body doesn't contain the expected values &
   /// 404 when uid doesn't match a channel.
   static makeOffline(HttpRequest req, HttpResponse res) async {
     final QueryModel body;
-    final List<Map<String, dynamic>> data;
+    final Map<String, dynamic> data;
 
     try {
       body = QueryModel.fromJson(await req.bodyAsJsonMap);
       await db.goOffline(body.uid!);
-      data = await db.getOnlineChannels();
+      data = await db.getChannel(body.uid!);
     }
     on PostgreSQLException catch (e){ // when uid does not match a channel
       logger.e(e.message, [e, e.stackTrace]);

--- a/server/controllers/channel_viewers.dart
+++ b/server/controllers/channel_viewers.dart
@@ -19,10 +19,12 @@ class ChannelViewersController {
   /// 409 when viewer already watched that channel.
   static addViewer(HttpRequest req, HttpResponse res) async {
     final QueryModel body;
+    final Map<String, dynamic> data;
 
     try {
       body = QueryModel.fromJson(await req.bodyAsJsonMap);
       await db.insertViewer(body.uid!, body.channelid!);
+      data = await db.getChannel(body.uid!);
     }
     on PostgreSQLException catch (e) { // when combination of uid and channelid already exists
       logger.e(e.message, [e, e.stackTrace]);
@@ -35,7 +37,7 @@ class ChannelViewersController {
       return e.toString();
     }
 
-    return null;
+    return data;
   }
 
   /// removes a viewer so it no longer watched the channel.
@@ -46,10 +48,12 @@ class ChannelViewersController {
   /// 400 when the request body doesn't contain the expected values.
   static deleteViewer(HttpRequest req, HttpResponse res) async {
     final QueryModel body;
+    final Map<String, dynamic> data;
 
     try {
       body = QueryModel.fromJson(await req.bodyAsJsonMap);
       await db.delViewer(body.uid!, body.channelid!);
+      data = await db.getChannel(body.uid!);
     }
     on PostgreSQLException catch (e) { // on db errors
       logger.e(e.message, [e, e.stackTrace]);
@@ -62,7 +66,7 @@ class ChannelViewersController {
       return e.toString();
     }
 
-    return null;
+    return data;
   }
 
   /// Clears all viewers from a channel.

--- a/server/controllers/channel_viewers.dart
+++ b/server/controllers/channel_viewers.dart
@@ -24,7 +24,7 @@ class ChannelViewersController {
     try {
       body = QueryModel.fromJson(await req.bodyAsJsonMap);
       await db.insertViewer(body.uid!, body.channelid!);
-      data = await db.getChannel(body.uid!);
+      data = await db.getChannel(body.channelid!);
     }
     on PostgreSQLException catch (e) { // when combination of uid and channelid already exists
       logger.e(e.message, [e, e.stackTrace]);
@@ -53,7 +53,7 @@ class ChannelViewersController {
     try {
       body = QueryModel.fromJson(await req.bodyAsJsonMap);
       await db.delViewer(body.uid!, body.channelid!);
-      data = await db.getChannel(body.uid!);
+      data = await db.getChannel(body.channelid!);
     }
     on PostgreSQLException catch (e) { // on db errors
       logger.e(e.message, [e, e.stackTrace]);

--- a/server/controllers/channel_viewers.dart
+++ b/server/controllers/channel_viewers.dart
@@ -14,6 +14,8 @@ class ChannelViewersController {
   ///
   /// **Request Body** a [QueryModel] that contains uid of viewer and channelid.
   ///
+  /// **Response Body** a [QueryModel] that contains the channel without account info.
+  ///
   /// **Error Status Codes** when it's executed successfully then 200 ok is returned,
   /// 400 when the request body doesn't contain the expected values &
   /// 409 when viewer already watched that channel.
@@ -43,6 +45,8 @@ class ChannelViewersController {
   /// removes a viewer so it no longer watched the channel.
   ///
   /// **Request Body** a [QueryModel] that contains uid of viewer and channelid.
+  ///
+  /// **Response Body** a [QueryModel] that contains the channel without account info.
   ///
   /// **Error Status Codes** when it's executed successfully then 200 ok is returned &
   /// 400 when the request body doesn't contain the expected values.

--- a/server/stream_server.dart
+++ b/server/stream_server.dart
@@ -10,65 +10,127 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:cmt_projekt/apis/database_api.dart';
 
-void main() async {
+void main() {
+  StreamServer();
+}
+
+/// A class for handling websocket connections meant for streaming
+class StreamServer {
   ///A map with all connected users.
   Map<WebSocketChannel, StreamController> connectedUsers = {};
 
   ///A map with all the rooms
   Map<String, RadioChannel> rooms = {};
 
+  /// Setups a websocket server at port 5605 using [handleIncomingConnections] as the connection handler
+  StreamServer() {
+    var handler = webSocketHandler(handleIncomingConnections);
+    shelf_io.serve(handler, '0.0.0.0', 5605).then((server) {
+      logger.i(
+          'Stream server serving at ws://${server.address.host}:${server.port} \n'
+          '(0.0.0.0 means all ips are accepted, which includes localhost)');
+    });
+  }
+
+  /// This method is the primary handler for connections not associated with a room.
+  /// It will check the intent pf the decoded json and sends to the relevant method based on that intent.
+  ///
+  /// If the intent is **j** then the [initClientStream] is called while for **h**
+  /// [initHostStream] is called.
+  void handleIncomingConnections(WebSocketChannel webSocket) async {
+    //Sets up so that clients that connect gets their own StreamController and is added to the list of connectedUsers.
+    connectedUsers[webSocket] = StreamController.broadcast();
+
+    //Sets up a listen function that sends incoming data from the web socket to the StreamController.
+    //The onDone function is called when the web socket connection is closed and handles the host/clients close methods.
+    webSocket.stream.listen((event) {
+      connectedUsers[webSocket]!.sink.add(event);
+    }, onDone: () {
+      connectedUsers[webSocket]!.close();
+    });
+
+    //The first listen function to the StreamController.
+    //Here the connected web socket is checked whether it is a host or client and calls the correct function accordingly.
+    connectedUsers[webSocket]!.stream.asBroadcastStream().listen((event) {
+      if (event.runtimeType == String) {
+        StreamMessage message = StreamMessage.fromJson(jsonDecode(event));
+        if (message.intent == "h" && !rooms.containsKey(message.hostId)) {
+          initHostStream(message, webSocket);
+        } else if (message.intent == "j" && rooms.containsKey(message.hostId)) {
+          initClientStream(message, webSocket);
+        } else if (message.intent == "j" &&
+            !rooms.containsKey(message.hostId)) {
+          webSocket.sink.close(4400, "room does not exist");
+        }
+      }
+    });
+  }
+
   ///This function is called when a host connects to the server and creates a radio channel with the host id.
   ///Also sets up a extra stream internally for the host-web socket for creating multiple listen functions.
-  Future<void> initHostStream(StreamMessage message, WebSocketChannel webSocket) async {
-    logger.v("A new host ${message.uid} has connected: Category: ${message.category}, Name: ${message.channelName}");
+  /// The new host stream will be added to [rooms] with host id as its key.
+  Future<void> initHostStream(
+      StreamMessage message, WebSocketChannel webSocket) async {
+    logger.v(
+        "A new host ${message.uid} has connected: Category: ${message.category}, Name: ${message.channelName}");
 
-    ///Creates a radio channel
     RadioChannel channel = RadioChannel(webSocket, message.hostId!);
 
     ///Adds the radio channel to the list of all radio channels.
     rooms[message.hostId!] = channel;
 
     ///Adds the radiochannel to the database if it doesn't already exist. After that the radio channel is toggled as online.
-    final res = await DatabaseApi.postRequest( '/channel' ,QueryModel.createChannel(
-        uid: message.uid,
-        channelname: message.channelName,
-        category: message.category
-    ));
+    final res = await DatabaseApi.postRequest(
+        '/channel',
+        QueryModel.createChannel(
+            uid: message.uid,
+            channelname: message.channelName,
+            category: message.category
+        ));
     sendData(webSocket, jsonEncode(res));
 
     ///Sets up a listen function specifically for the host. It is used to let the host send messages to all clients connected to the hosts radio channel.
     ///OnDone disconnects all clients from the radio channel and removes the channel from the list.
-    connectedUsers[webSocket]!.stream.asBroadcastStream().listen((message) async {
+    connectedUsers[webSocket]!.stream.asBroadcastStream().listen(
+        (message) async {
+          // forwards all binary (audio) data to all listening clients
       if (message.runtimeType != String) {
         for (WebSocketChannel sock in channel.connectedAudioClients) {
           sendData(sock, message);
         }
-      } else {
+      } else { // decodes json messages, updates channel info and forwards new channel info to all clients
         StreamMessage msg = StreamMessage.fromJson(jsonDecode(message));
-        if(msg.intent == "u"){
-          var res = await DatabaseApi.postRequest('/channel', QueryModel.createChannel(
-              uid: msg.uid,
-              channelname: msg.channelName,
-              category: msg.category
-          ));
+        if (msg.intent == "u") {
+          var res = await DatabaseApi.postRequest(
+              '/channel',
+              QueryModel.createChannel(
+                  uid: msg.uid,
+                  channelname: msg.channelName,
+                  category: msg.category));
 
           res = jsonEncode(res);
 
+          // sends updated channel information to all the listening clients/host
           sendData(webSocket, res);
-          for(WebSocketChannel sock in channel.connectedAudioClients){
+          for (WebSocketChannel sock in channel.connectedAudioClients) {
             sendData(sock, res);
           }
-
         }
       }
-    }, onDone: () async {
+    }, onDone: () async { // disconnects all clients when host is disconnected
       for (WebSocketChannel client in channel.connectedAudioClients) {
-        client.sink.close(1000, "Rum ${channel.channelId} stängdes");
+        client.sink.close(1000, "Room ${channel.channelId} closed");
       }
       logger.v("Channel ${message.uid} closed");
       rooms.remove(channel.channelId);
-      await DatabaseApi.deleteRequest('/channel', QueryModel.channelOffline(uid: channel.channelId));
-      await DatabaseApi.deleteRequest('/channel/viewers/all', QueryModel.delViewers(channelid: message.hostId));
+      await DatabaseApi.deleteRequest(
+          '/channel',
+          QueryModel.channelOffline(uid: channel.channelId)
+      );
+      await DatabaseApi.deleteRequest(
+          '/channel/viewers/all',
+          QueryModel.delViewers(channelid: message.hostId)
+      );
       connectedUsers.remove(webSocket);
     });
   }
@@ -87,74 +149,41 @@ void main() async {
     room.addAudioViewer(webSocket);
 
     ///Adds the viewer of said radio channel to the database.
-    var res = await DatabaseApi.postRequest(
-        '/channel/viewers',
-        QueryModel.addViewers(channelid: message.hostId, uid: message.uid)
-    );
+    var res = await DatabaseApi.postRequest('/channel/viewers',
+        QueryModel.addViewers(channelid: message.hostId, uid: message.uid));
 
     res = jsonEncode(res);
 
+    // sends updated channel information to all the listening clients/host
     sendData(room.streamAudioHost, res);
-    for(WebSocketChannel sock in room.connectedAudioClients){
+    for (WebSocketChannel sock in room.connectedAudioClients) {
       sendData(sock, res);
     }
 
-    ///Sets up a listen function with the sole purpose of disconnecting clients with onDone.
+    ///Sets up a listen function with the sole purpose of handling disconnecting clients with onDone.
     connectedUsers[webSocket]!.stream.asBroadcastStream().listen((event) {},
         onDone: () async {
       logger.v("Client ${message.uid} left ${message.hostId}");
       var res = await DatabaseApi.deleteRequest(
           '/channel/viewers',
-          QueryModel.delViewer(channelid: message.hostId, uid: message.uid)
-      ); // -
+          QueryModel.delViewer(
+              channelid: message.hostId, uid: message.uid)); // -
       room.disconnectAudioViewer(webSocket);
-      webSocket.sink.close(10006, "lämnade servern");
+      webSocket.sink.close(1000, "lämnade servern");
       connectedUsers.remove(webSocket);
 
       res = jsonEncode(res);
 
+      // sends updated channel information to all the listening clients/host
       sendData(room.streamAudioHost, res);
-      for(WebSocketChannel sock in room.connectedAudioClients){
+      for (WebSocketChannel sock in room.connectedAudioClients) {
         sendData(sock, res);
       }
     });
   }
 
-  var handler = webSocketHandler((WebSocketChannel webSocket) {
-    ///Sets up so that clients that connect gets their own StreamController and is added to the list of connectedUsers.
-    connectedUsers[webSocket] = StreamController.broadcast();
-
-    ///Sets up a listen function that sends incoming data from the web socket to the StreamController.
-    ///The onDone function is called when the web socket connection is closed and handles the host/clients close methods.
-    webSocket.stream.listen((event) {
-      connectedUsers[webSocket]!.sink.add(event);
-    }, onDone: () {
-      connectedUsers[webSocket]!.close();
-    });
-
-    ///The first listen function to the StreamController. Here the connected web socket is checked whether it is a host or client and calls the correct function accordingly.
-    connectedUsers[webSocket]!.stream.asBroadcastStream().listen((event) {
-      if (event.runtimeType == String) {
-        StreamMessage message = StreamMessage.fromJson(jsonDecode(event));
-        if (message.intent == "h" && !rooms.containsKey(message.hostId)) {
-          initHostStream(message, webSocket);
-        } else if (message.intent == "j" &&
-            rooms.containsKey(message.hostId)) {
-          initClientStream(message, webSocket);
-        } else if (message.intent == "j" &&
-            !rooms.containsKey(message.hostId)) {
-          webSocket.sink.close(4400, "rummet finns inte");
-        }
-      }
-    });
-  });
-  shelf_io.serve(handler, '0.0.0.0', 5605).then((server) {
-    logger.i('Stream server serving at ws://${server.address.host}:${server.port} \n'
-        '(0.0.0.0 means all ips are accepted, which includes localhost)');
-  });
-}
-
-///An asynchronous function that given data to the given web socket.
-Future<void> sendData(WebSocketChannel client, message) async {
-  client.sink.add(message);
+  ///An asynchronous function that given data to the given web socket.
+  Future<void> sendData(WebSocketChannel client, message) async {
+    client.sink.add(message);
+  }
 }

--- a/server/stream_server.dart
+++ b/server/stream_server.dart
@@ -92,7 +92,6 @@ void main() async {
         QueryModel.addViewers(channelid: message.hostId, uid: message.uid)
     );
 
-    res["total"] = room.connectedAudioClients.length;
     res = jsonEncode(res);
 
     sendData(room.streamAudioHost, res);
@@ -112,7 +111,6 @@ void main() async {
       webSocket.sink.close(10006, "lämnade servern");
       connectedUsers.remove(webSocket);
 
-      res["total"] = room.connectedAudioClients.length;
       res = jsonEncode(res);
 
       sendData(room.streamAudioHost, res);


### PR DESCRIPTION
- Made so the stream server and the app can differentiate string json messages and binary audio data in websocket. 
- Added a "u" (update) command so stream server updates channel data and sends the updated channel data to all listening clients.
- Made so the app in the listening and hosting ui auto updates with new info when they get them trough the websocket.
- reused the go live modal in the hosting ui to send channel info updates to stream server


- fixed the bug where the channel closed dialog appeared when the user pressed the back button
- fixed the "gå till startsidan" button so it works as intended


- on dbserver changed so post to `/channel`  and post/delete to `/channel/viewer` responds with the the updated channel instead of all channels or nothing
- on dbserver changed so get `/channel` only responds with only channels that are online instead of all of them.


- did a little refactoring
- and more documentation regarding the streaming 